### PR TITLE
Stable autoinstaller script fixed

### DIFF
--- a/stable/autoinstall.sh
+++ b/stable/autoinstall.sh
@@ -1,5 +1,8 @@
-for $module in sugar{-artwork, -toolkit-gtk3, -datastore, ,-runner, -toolkit2-gtk3}; do
+#!/bin/sh
+for module in sugar-artwork sugar-toolkit-gtk3 sugar-datastore sugar sugar-runner sugar-toolkit2-gtk3 gwebsockets;
+do
 	cd $module
 	makepkg -si 
 	cd ..
+done
 echo Done


### PR DESCRIPTION
The autoinstaller in the Stable directory works. As you advised earlier, installing [Debian
derived python3-empy](https://github.com/srevinsaju/python3-empy-AUR) fixes the empy error.